### PR TITLE
Fontello

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ Params:
 setup-font-face('fontello', '/assets/font/', 'fontello-alt')
 ```
 
+## Fontello
+
+Includes base fontello icon styling
+
+```stylus
+.icon:before
+  fontello-icon()
+  content '\e200'
+
 # TODO
 
 * Touch detection

--- a/README.md
+++ b/README.md
@@ -78,9 +78,22 @@ Makes an element only available to screen-readers, aiding in accessibility.
 }
 ```
 
+## Font Face
+
+Sets up font face.
+
+Params:
+
+1. font-family name
+2. file root (optional, defaults to `/fonts/`)
+3. file name (optional, defaults to font-family name)
+
+```stylus
+setup-font-face('fontello', '/assets/font/', 'fontello-alt')
+```
+
 # TODO
 
-* Fontello setup
 * Touch detection
 * Viewport filled and centered content
 * Responsive show and hide

--- a/README.md
+++ b/README.md
@@ -96,10 +96,13 @@ setup-font-face('fontello', '/assets/font/', 'fontello-alt')
 
 Includes base fontello icon styling
 
+Has an optional boolean parameter for whether to include animation offset.
+
 ```stylus
 .icon:before
   fontello-icon()
   content '\e200'
+```
 
 # TODO
 

--- a/lib/sop-styl/fontello.styl
+++ b/lib/sop-styl/fontello.styl
@@ -1,0 +1,12 @@
+fontello(fontFamily, path = '/fonts/')
+  @font-face
+    font-family fontFamily
+    src: url(path + fontFamily + '.eot');
+    src: url(path + fontFamily + '.eot#iefix') format('embedded-opentype'),
+         url(path + fontFamily + '.woff') format('woff'),
+         url(path + fontFamily + '.ttf') format('truetype'),
+         url(path + fontFamily + '.svg#' + fontFamily) format('svg');
+    font-weight normal
+    font-style normal
+
+fontello('too')

--- a/lib/sop-styl/fontello.styl
+++ b/lib/sop-styl/fontello.styl
@@ -1,10 +1,45 @@
-fontello(fontFamily, path = '/fonts/')
+setup-font-face(fontFamily, path = '/fonts/', fontFile = fontFamily)
   @font-face
     font-family fontFamily
-    src: url(path + fontFamily + '.eot');
-    src: url(path + fontFamily + '.eot#iefix') format('embedded-opentype'),
-         url(path + fontFamily + '.woff') format('woff'),
-         url(path + fontFamily + '.ttf') format('truetype'),
-         url(path + fontFamily + '.svg#' + fontFamily) format('svg');
+    src: url(path + fontFile + '.eot');
+    src: url(path + fontFile + '.eot#iefix') format('embedded-opentype'),
+         url(path + fontFile + '.woff') format('woff'),
+         url(path + fontFile + '.ttf') format('truetype'),
+         url(path + fontFile + '.svg#' + fontFile) format('svg');
     font-weight normal
     font-style normal
+
+fontello-icon(shouldAnimate = false)
+  font-family "fontello"
+  font-style normal
+  font-weight normal
+  speak none
+
+  display inline-block
+  text-decoration inherit
+  width 1em
+  margin-right .2em
+  text-align center
+
+  /**
+   * For safety - reset parent styles, that can break glyph codes
+   */
+  font-variant normal
+  text-transform none
+
+  /**
+   * fix buttons height, for twitter bootstrap
+   */
+  line-height 1em
+
+  if shouldAnimate
+    /*
+     * Animation center compensation - margins should be symmetric
+     */
+    margin-left .2em
+
+  /**
+   * Font smoothing. That was taken from TWBS
+   */
+  -webkit-font-smoothing antialiased
+  -moz-osx-font-smoothing grayscale

--- a/lib/sop-styl/fontello.styl
+++ b/lib/sop-styl/fontello.styl
@@ -8,5 +8,3 @@ fontello(fontFamily, path = '/fonts/')
          url(path + fontFamily + '.svg#' + fontFamily) format('svg');
     font-weight normal
     font-style normal
-
-fontello('too')

--- a/test/cases/fontello.css
+++ b/test/cases/fontello.css
@@ -1,0 +1,7 @@
+@font-face {
+  font-family: 'foob';
+  src: url("/fonts/foob.eot");
+  src: url("/fonts/foob.eot#iefix") format('embedded-opentype'), url("/fonts/foob.woff") format('woff'), url("/fonts/foob.ttf") format('truetype'), url("/fonts/foob.svg#foob") format('svg');
+  font-weight: normal;
+  font-style: normal;
+}

--- a/test/cases/fontello.css
+++ b/test/cases/fontello.css
@@ -1,3 +1,17 @@
+@font-face {
+  font-family: 'foo';
+  src: url("/fonts/foo.eot");
+  src: url("/fonts/foo.eot#iefix") format('embedded-opentype'), url("/fonts/foo.woff") format('woff'), url("/fonts/foo.ttf") format('truetype'), url("/fonts/foo.svg#foo") format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'bar';
+  src: url("/build/bar-file.eot");
+  src: url("/build/bar-file.eot#iefix") format('embedded-opentype'), url("/build/bar-file.woff") format('woff'), url("/build/bar-file.ttf") format('truetype'), url("/build/bar-file.svg#bar-file") format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
 .icon:before {
   font-family: "fontello";
   font-style: normal;

--- a/test/cases/fontello.css
+++ b/test/cases/fontello.css
@@ -1,7 +1,48 @@
-@font-face {
-  font-family: 'foob';
-  src: url("/fonts/foob.eot");
-  src: url("/fonts/foob.eot#iefix") format('embedded-opentype'), url("/fonts/foob.woff") format('woff'), url("/fonts/foob.ttf") format('truetype'), url("/fonts/foob.svg#foob") format('svg');
-  font-weight: normal;
+.icon:before {
+  font-family: "fontello";
   font-style: normal;
+  font-weight: normal;
+  speak: none;
+  display: inline-block;
+  text-decoration: inherit;
+  width: 1em;
+  margin-right: 0.2em;
+  text-align: center;
+/**
+   * For safety - reset parent styles, that can break glyph codes
+   */
+  font-variant: normal;
+  text-transform: none;
+/**
+   * fix buttons height, for twitter bootstrap
+   */
+  line-height: 1em;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.animate-icon:before {
+  font-family: "fontello";
+  font-style: normal;
+  font-weight: normal;
+  speak: none;
+  display: inline-block;
+  text-decoration: inherit;
+  width: 1em;
+  margin-right: 0.2em;
+  text-align: center;
+/**
+   * For safety - reset parent styles, that can break glyph codes
+   */
+  font-variant: normal;
+  text-transform: none;
+/**
+   * fix buttons height, for twitter bootstrap
+   */
+  line-height: 1em;
+/*
+     * Animation center compensation - margins should be symmetric
+     */
+  margin-left: 0.2em;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }

--- a/test/cases/fontello.styl
+++ b/test/cases/fontello.styl
@@ -1,0 +1,3 @@
+@import 'sop-styl/fontello'
+
+fontello('foob')

--- a/test/cases/fontello.styl
+++ b/test/cases/fontello.styl
@@ -1,8 +1,8 @@
 @import 'sop-styl/fontello'
 
-fontello('foo')
+setup-font-face('foo')
 
-fontello('bar', '/build/', 'bar-file')
+setup-font-face('bar', '/build/', 'bar-file')
 
 .icon:before
   fontello-icon()

--- a/test/cases/fontello.styl
+++ b/test/cases/fontello.styl
@@ -1,3 +1,11 @@
 @import 'sop-styl/fontello'
 
-fontello('foob')
+fontello('foo')
+
+fontello('bar', '/build/', 'bar-file')
+
+.icon:before
+  fontello-icon()
+
+.animate-icon:before
+  fontello-icon(true)


### PR DESCRIPTION
# setup-font-face

Sets up font face. 

Params:

1. font-family name
2. file root (optional, defaults to `/font/`)
3. file name (optional, defaults to font-family name)

# fontello-icon

Sets up basics for Fontello icon styling. Has an optional boolean parameter for whether to include animation offset.